### PR TITLE
quote scalar in config

### DIFF
--- a/Resources/config/config.yml
+++ b/Resources/config/config.yml
@@ -29,12 +29,12 @@ services:
   phystrix.circuit_breaker_factory:
     class: %phystrix.circuit_breaker_factory.class%
     arguments:
-      - @phystrix.state_storage
+      - "@phystrix.state_storage"
 
   phystrix.command_metrics_factory:
     class: %phystrix.command_metrics_factory.class%
     arguments:
-      - @phystrix.state_storage
+      - "@phystrix.state_storage"
 
   phystrix.request_cache:
     class: %phystrix.request_cache.class%
@@ -45,16 +45,16 @@ services:
   phystrix.command_factory:
     class: %phystrix.command_factory.class%
     arguments:
-      - @phystrix.configuration
-      - @phystrix.service_locator
-      - @phystrix.circuit_breaker_factory
-      - @phystrix.command_metrics_factory
-      - @phystrix.request_cache
-      - @phystrix.request_log
+      - "@phystrix.configuration"
+      - "@phystrix.service_locator"
+      - "@phystrix.circuit_breaker_factory"
+      - "@phystrix.command_metrics_factory"
+      - "@phystrix.request_cache"
+      - "@phystrix.request_log"
 
   phystrix.data_collector:
     class: %phystrix.data_collector.class%
     arguments:
-      - @phystrix.request_log
+      - "@phystrix.request_log"
     tags:
       - { name: data_collector, template: "OdeskPhystrixBundle:Collector:phystrix", id: "phystrix"}


### PR DESCRIPTION
Hello,

I'm not sur you'll accept PR from github, but if it's the case:

deprecation notices are displayed when i use your bundle in my project.
phpunit's tests are failing after a fresh clone and composer update.

```
1) Odesk\Bundle\PhystrixBundle\Tests\DependencyInjection\OdeskPhystrixExtensionTest::testServiceIsPublic with data set #0 ('phystrix.command_factory')
Symfony\Component\DependencyInjection\Exception\InvalidArgumentException: The file "/home/bpaulin/phystrix-bundle/DependencyInjection/../Resources/config/config.yml" does not contain valid YAML.

/home/bpaulin/phystrix-bundle/vendor/symfony/dependency-injection/Loader/YamlFileLoader.php:366
/home/bpaulin/phystrix-bundle/vendor/symfony/dependency-injection/Loader/YamlFileLoader.php:44
/home/bpaulin/phystrix-bundle/DependencyInjection/OdeskPhystrixExtension.php:41
/home/bpaulin/phystrix-bundle/Tests/DependencyInjection/OdeskPhystrixExtensionTest.php:53
/usr/share/php/PHPUnit/TextUI/Command.php:147
/usr/share/php/PHPUnit/TextUI/Command.php:99

Caused by
Symfony\Component\Yaml\Exception\ParseException: The reserved indicator "@" cannot start a plain scalar; you need to quote the scalar at line 32 (near "- @phystrix.state_storage").
```

Thanks!
